### PR TITLE
Miner Relay Service fails to start

### DIFF
--- a/minerrelayservice/config.go
+++ b/minerrelayservice/config.go
@@ -48,8 +48,12 @@ func NewMinerRelayServiceConfig(cnffile *sys.Inicnf) *MinerRelayServiceConfig {
 	cnf.IsAcceptHashrate = cnfsection.Key("accept_hashrate").MustBool(true)
 	// max
 	cnf.MaxWorkerConnect = cnfsection.Key("max_connect").MustInt(200)
-	cnf.ServerTcpListenPort = cnfsection.Key("server_listen_port").MustInt(0)
-	cnf.HttpApiListenPort = cnfsection.Key("http_api_listen_port").MustInt(0)
+	cnf.ServerTcpListenPort = cnfsection.Key("server_listen_port").MustInt(19991)
+	if cnf.ServerTcpListenPort == 0 {
+        	panic("Relay service:server listen port is zero")
+      	}
+
+	cnf.HttpApiListenPort = cnfsection.Key("http_api_listen_port").MustInt(8080)
 	// store
 	storesection := cnffile.Section("store")
 	cnf.StoreEnable = storesection.Key("enable").MustBool(false)


### PR DESCRIPTION
This code change related to [https://github.com/hacash/miner/issues/8].

The problem was the [server_listen_port] and [http_api_listen_port] were set to zero [0].
When Miner Relay Service was started, the service failed with messages:

config server_listen_port==0 do not start server.
config http_api_listen_port==0 do not start http api service.
connecting server <:0>... [Miner Relay Service] connect to server <:0> error:
dial tcp :0: connectex: The requested address is not valid in its context.
[Miner Relay Service] Reconnection will be initiated in two minutes...

In the documentation for [Miner Relay Service] [https://github.com/hacash/service/blob/master/doc/miner_service_api.cn.md],
the port specified for [server_listen_port] is [19991],
the port specified for [http_api_listen_port] is [8080].

Additional code was added to terminate the [Miner Relay Service] if [server_listen_port] is zero [0], since there is no possibility that the service can be started.


THANX(MKD).